### PR TITLE
Feature/filter rules

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,20 +18,41 @@ new one.
 The following steps are a probably helpful guideline
 
 * Add your case to the ``corpus.py`` file and run the corpus tests
-  using ``py.test tests/test_run_corpus.py``. If the tests do not
-  fail, rebuild the model and try again:
+  using ``py.test tests/test_run_corpus.py``. Now basically two things can happen:
 
-  .. code:: python
+  #. **The tests pass**, which means ``ctparse`` can correctly resolve
+     the expression. It might not score it highest. To check this,
+     rebuild the model and try parsing the expression again:
+
+     .. code:: python
+
+            from ctparse.ctparse import regenerate_model
+
+            regenerate_model()
+
+     To avoid issues with reloading, pls. restart the python
+     interpreter after regenerating the model.
+
+     If this fixes the issue please commit the updated ``corpus.py``
+     and the updated model as a PR. The scoring can be influenced by
+     adding more structurally identical examples to the corpus. Seeing
+     more samples where a specific sequence of rule applications leads
+     to the correct ranking will drive the model to favor these. This
+     comes, however, at the potential price of downranking certain
+     other production sequences. Although it would generally be
+     considered more favorable to add varying test cases (e.g. in
+     different languages, slight variation) to the corpus, the same
+     string can also just be duplicated to achive this *implict
+     up-weightning* effect.
    
-    from ctparse.ctparse import regenerate_model
+  #. **The tests fail**: if this is because not all tests in the
+     corpus pass, i.e. you get an error message like the following::
 
-    regenerate_model()
+       ctparse.py 527 WARNING  failure: target "Time[]{2019-X-X X:X (X/X)}" never produced in "2019"
+       ctparse.py 532 WARNING  failure: "Time[]{2019-X-X X:X (X/X)}" not always produced
 
-  To avoid issues with reloading, pls. restart the python interpreter
-  after regenerating the model.
+     then you need to adjust the rules.
 
-  If this fixes the issue please commit the updated ``corpus.py`` and
-  the updated model as a PR.
 
 * If the tests fail, run ``ctparse`` in debug mode to see what goes wrong:
 
@@ -67,6 +88,14 @@ The following steps are a probably helpful guideline
   If relevant parts of your expression were not picked up, this is an
   indicator that you should either modify an existing regular
   expression or need to add a new rule (see below).
+
+  Next you see how many of the total rules are applicable in this parse at all::
+
+    ================================================================================
+    -> check rule applicability
+    of 75 total rules 23 are applicable
+    time in _filter_rules: 0ms
+    ================================================================================
 
   Next you see the unique sub-sequences constructed based on these
   regular expressions (plus again the time used to build them)::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,14 +89,6 @@ The following steps are a probably helpful guideline
   indicator that you should either modify an existing regular
   expression or need to add a new rule (see below).
 
-  Next you see how many of the total rules are applicable in this parse at all::
-
-    ================================================================================
-    -> check rule applicability
-    of 75 total rules 23 are applicable
-    time in _filter_rules: 0ms
-    ================================================================================
-
   Next you see the unique sub-sequences constructed based on these
   regular expressions (plus again the time used to build them)::
             
@@ -111,6 +103,21 @@ The following steps are a probably helpful guideline
     stack length after relative match length: 1
     stack length after max stack depth limit: 1
     ================================================================================
+
+  This is followed by a summary of how many applicable rules there are
+  per initial stack element::
+
+    ================================================================================
+    -> checking rule applicability
+    of 75 total rules 20 are applicable in (RegexMatch[0-3]{114:May}, RegexMatch[4-7]{135:5th})
+    time in _filter_rules: 0ms
+    ================================================================================
+    ================================================================================
+    -> checking rule applicability
+    of 75 total rules 20 are applicable in (RegexMatch[0-3]{114:May}, RegexMatch[4-5]{148:5})
+    time in _filter_rules: 0ms
+    ================================================================================
+    ...
 
   Again, if you do not see any sequence that captures all relevant
   parts of your input, you may need to modify the regular expressions

--- a/ctparse/ctparse.py
+++ b/ctparse/ctparse.py
@@ -148,7 +148,8 @@ def _ctparse(txt, ts=None, timeout=0, relative_match_len=0, max_stack_depth=0):
         logger.debug('='*80)
         logger.debug('-> check rule applicability')
         applicable_rules, _ts = _timeit(_filter_rules)(p)
-        logger.debug('of {} total rules {} are applicable'.format(len(rules), len(applicable_rules)))
+        logger.debug('of {} total rules {} are applicable'.format(
+            len(rules), len(applicable_rules)))
         logger.debug('time in _filter_rules: {:.0f}ms'.format(1000*_ts))
 
         logger.debug('='*80)

--- a/ctparse/ctparse.py
+++ b/ctparse/ctparse.py
@@ -144,6 +144,13 @@ def _ctparse(txt, ts=None, timeout=0, relative_match_len=0, max_stack_depth=0):
         logger.debug('-> matching regular expressions')
         p, _tp = _timeit(_match_regex)(txt)
         logger.debug('time in _match_regex: {:.0f}ms'.format(1000*_tp))
+
+        logger.debug('='*80)
+        logger.debug('-> check rule applicability')
+        applicable_rules, _ts = _timeit(_filter_rules)(p)
+        logger.debug('of {} total rules {} are applicable'.format(len(rules), len(applicable_rules)))
+        logger.debug('time in _filter_rules: {:.0f}ms'.format(1000*_ts))
+
         logger.debug('='*80)
         logger.debug('-> building initial stack')
         stack, _ts = _timeit(_regex_stack)(txt, p, t_fun)
@@ -175,7 +182,7 @@ def _ctparse(txt, ts=None, timeout=0, relative_match_len=0, max_stack_depth=0):
             logger.debug('-'*80)
             logger.debug('producing on {}, score={:.2f}'.format(s.prod, s.score))
             new_stack = []
-            for r_name, r in rules.items():
+            for r_name, r in applicable_rules.items():
                 for r_match in _match_rule(s.prod, r[1]):
                     # apply production part of rule
                     new_s = s.apply_rule(ts, r, r_name, r_match)
@@ -290,6 +297,77 @@ def _match_rule(seq, rule):
             if i_r == r_len:
                 yield i_s, i_start
         i_s += 1
+
+
+def _filter_rules(seq):
+    def _hasNext(it):
+        try:
+            next(it)
+            return True
+        except StopIteration as e:
+            return False
+
+    return {rule_name: r for rule_name, r in rules.items()
+            if _hasNext(_seq_match(seq, r[1]))}
+
+
+def _seq_match(seq, pat, offset=0):
+    # :param seq: a list of intermediate productions, either of type
+    # RegexMatch or some other Artifact
+    #
+    # :param pat: a list of rule patterns to be matched, i.e. either a
+    # RegexMatch or a callable
+    #
+    # Determine whether the pattern pat matches the sequence seq and
+    # return a list of lists, where each sub-list contains those
+    # indices where the RegexMatch objects in pat are located in seq.
+    #
+    # A pattern pat only matches seq, iff each RegexMatch in pat is in
+    # seq in the same order and iff between two RegexMatches aligned
+    # to seq there is at least one additional element in seq. Reason:
+    #
+    # * Rule patterns never have two consequitive RegexMatch objects.
+    #
+    # * Hence there must be some predicate/dimension between two
+    # * RegexMatch objects.
+    #
+    # * For the whole pat to match there must then be at least one
+    #  element in seq that can product this intermediate bit
+    #
+    # If pat does not start with a RegexMatch then there must be at
+    # least one element in seq before the first RegexMatch in pat that
+    # is alignes on seq. Likewise, if pat does not end with a
+    # RegexMatch, then there must be at least one additional element
+    # in seq to match the last non-RegexMatch element in pat.
+    #
+    # STRONG ASSUMPTIONS ON ARGUMENTS: seq and pat do not contain
+    # consequiteve elements which are both of type RegexMatch! Callers
+    # obligation to ensure this!
+
+    if not seq or not pat:
+        # if either seq or pat is empty there will be no match
+        yield []
+    elif pat[-1].__name__ != '_regex_match':
+        # there must be at least one additional element in seq at the
+        # end
+        yield from _seq_match(seq[:-1], pat[:-1], offset)
+    elif len(pat) > len(seq):
+        # if pat is longer than seq it cannot match
+        yield []
+    else:
+        p1 = pat[0]
+        # if p1 is not a RegexMatch, then continue on next pat and
+        # advance sequence by one
+        if p1.__name__ != '_regex_match':
+            yield from _seq_match(seq[1:], pat[1:], offset+1)
+        else:
+            # For each occurance of RegexMatch pat[0] in seq
+            for iseq, s in enumerate(seq):
+                # apply _regex_match check
+                if p1(s):
+                    # for each match of pat[1:] in seq[iseq+1:], yield a result
+                    for subm in _seq_match(seq[iseq+1:], pat[1:], offset+iseq+1):
+                        yield [iseq+offset+1] + subm
 
 
 def _match_regex(txt):

--- a/ctparse/rule.py
+++ b/ctparse/rule.py
@@ -62,6 +62,12 @@ def rule(*patterns):
         else:
             return p
 
+    def _has_consequtive_regex(ps):
+        for p0, p1 in zip(ps[:-1], ps[1:]):
+            if isinstance(p0, str) and isinstance(p1, str):
+                return True
+        return False
+
     mapped_patterns = [_map(p) for p in patterns]
 
     def fwrapper(f):

--- a/ctparse/rule.py
+++ b/ctparse/rule.py
@@ -62,7 +62,7 @@ def rule(*patterns):
         else:
             return p
 
-    patterns = [_map(p) for p in patterns]
+    mapped_patterns = [_map(p) for p in patterns]
 
     def fwrapper(f):
         def wrapper(ts, *args):
@@ -75,7 +75,12 @@ def rule(*patterns):
             except ValueError:
                 return
             return res
-        rules[f.__name__] = (wrapper, patterns)
+        # check that in rules we never have a regex followed by a regex -
+        # that must be merged into one regex
+        if _has_consequtive_regex(patterns):
+            raise ValueError('rule {} contains consequtive regular expressions'.format(
+                f.__name__))
+        rules[f.__name__] = (wrapper, mapped_patterns)
         return wrapper
     return fwrapper
 


### PR DESCRIPTION
Before starting to apply rules, reduce rule set to those rules that can at all be applicable. For all rules that contain regular expressions, each regular expressions must appear in the right order in the initial parse (i.e. `StackElement`) and there must be at least one element in the stack for each intermediate property based element in the rule.