### PR TITLE
Extract timers as a separate module

### DIFF
--- a/ctparse/ctparse.py
+++ b/ctparse/ctparse.py
@@ -10,8 +10,8 @@ from tqdm import tqdm
 
 from .nb import NB
 from .rule import _regex, rules
-# Avoid collision with variable "timeout"
 from .timers import CTParseTimeoutError, timeit
+# Avoid collision with variable "timeout"
 from .timers import timeout as timeout_
 from .types import RegexMatch
 

--- a/ctparse/ctparse.py
+++ b/ctparse/ctparse.py
@@ -1,50 +1,21 @@
-import logging
-import regex
-import pickle
 import bz2
+import logging
 import os
-from tqdm import tqdm
-from time import perf_counter
+import pickle
 from datetime import datetime
 from math import log
-from functools import wraps
 
-from . types import RegexMatch
-from . nb import NB
-from . rule import rules, _regex
+import regex
+from tqdm import tqdm
 
+from .nb import NB
+from .rule import _regex, rules
+# Avoid collision with variable "timeout"
+from .timers import CTParseTimeoutError, timeit
+from .timers import timeout as timeout_
+from .types import RegexMatch
 
 logger = logging.getLogger(__name__)
-
-
-class TimeoutError(Exception):
-    pass
-
-
-def _timeout(timeout):
-    start_time = perf_counter()
-
-    def _tt():
-        if timeout == 0:
-            return
-        if perf_counter() - start_time > timeout:
-            raise TimeoutError()
-    return _tt
-
-
-def _timeit(f):
-    """timeit wrapper, use as `timeit(f)(args)
-
-    Will return a tuple (f(args), t) where t the time in seconds the function call
-    took to run.
-
-    """
-    @wraps(f)
-    def _wrapper(*args, **kwargs):
-        start_time = perf_counter()
-        res = f(*args, **kwargs)
-        return res, perf_counter() - start_time
-    return _wrapper
 
 
 class StackElement:
@@ -73,7 +44,7 @@ class StackElement:
         # Reducing rules to only those applicable has no effect for
         # small stacks, but on larger there is a 10-20% speed
         # improvement
-        se.applicable_rules, _ts = _timeit(se._filter_rules)(rules)
+        se.applicable_rules, _ts = timeit(se._filter_rules)(rules)
         logger.debug('of {} total rules {} are applicable in {}'.format(
             len(rules), len(se.applicable_rules), se.prod))
         logger.debug('time in _filter_rules: {:.0f}ms'.format(1000*_ts))
@@ -164,19 +135,19 @@ def _ctparse(txt, ts=None, timeout=0, relative_match_len=0, max_stack_depth=0):
         else:
             return 0.0
 
-    t_fun = _timeout(timeout)
+    t_fun = timeout_(timeout)
 
     try:
         if ts is None:
             ts = datetime.now()
         logger.debug('='*80)
         logger.debug('-> matching regular expressions')
-        p, _tp = _timeit(_match_regex)(txt)
+        p, _tp = timeit(_match_regex)(txt)
         logger.debug('time in _match_regex: {:.0f}ms'.format(1000*_tp))
 
         logger.debug('='*80)
         logger.debug('-> building initial stack')
-        stack, _ts = _timeit(_regex_stack)(txt, p, t_fun)
+        stack, _ts = timeit(_regex_stack)(txt, p, t_fun)
         logger.debug('time in _regex_stack: {:.0f}ms'.format(1000*_ts))
         # add empty production path + counter of contained regex
         stack = [StackElement.from_regex_matches(s, len(txt)) for s in stack]
@@ -244,7 +215,7 @@ def _ctparse(txt, ts=None, timeout=0, relative_match_len=0, max_stack_depth=0):
                 stack = stack[-max_stack_depth:]
                 logger.debug('added {} new stack elements, depth after trunc: {}'.format(
                     len(new_stack), len(stack)))
-    except TimeoutError as e:
+    except CTParseTimeoutError:
         logger.debug('Timeout on "{}"'.format(txt))
         return
 

--- a/ctparse/timers.py
+++ b/ctparse/timers.py
@@ -1,0 +1,66 @@
+"""Utilities for tracking time spent in functions.
+
+Although this module is not part of the public API, it is used in various parts of
+the ctparse package.
+
+"""
+from time import perf_counter
+from typing import Callable, TypeVar, Union, Tuple
+from functools import wraps
+
+T = TypeVar('T')
+
+
+def timeout(timeout: Union[float, int]) -> Callable[[], None]:
+    """Generate a functions that raises an exceptions if a timeout has passed.
+
+    Example:
+
+        sentinel = timeout(1.0)
+        time.sleep(0.5)
+        sentinel() # Do nothing
+        time.sleep(0.6)
+        sentinel() # Raises CTParseTimeoutException
+
+    :param timeout:
+       time in seconds. If it is equal to zero, it means to never raise an exception.
+    :returns:
+        A function that raises a `CTParseTimeoutException` if `timeout` seconds have expired.
+    """
+    start_time = perf_counter()
+
+    def _tt():
+        if timeout == 0:
+            return
+        if perf_counter() - start_time > timeout:
+            raise CTParseTimeoutError()
+    return _tt
+
+
+def timeit(f: Callable[..., T]) -> Callable[..., Tuple[T, float]]:
+    """Wrapper to time a function.
+
+    The wrapped function is modified so that it returns a tuple `(f(args), t)`
+    where `t` the time in seconds the function call took to run.
+
+    Example:
+
+        def fun(x):
+            return x * x
+
+        result, exec_time = timeit(fun)(3)
+
+    """
+    @wraps(f)
+    def _wrapper(*args, **kwargs):
+        start_time = perf_counter()
+        res = f(*args, **kwargs)
+        return res, perf_counter() - start_time
+    return _wrapper
+
+
+# NOTE: TimeoutError is a built-in exception that means that
+# system function timed out at the system level. Hence we opt
+# for a custom exception.
+class CTParseTimeoutError(Exception):
+    """Exception raised by the `timeout` function."""

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 pip==19.1.1
 bumpversion==0.5.3
-wheel==0.33.2
 watchdog==0.9.0
 flake8==3.7.7
 tox==3.9.0

--- a/tests/test_ctparse.py
+++ b/tests/test_ctparse.py
@@ -1,18 +1,10 @@
 from unittest import TestCase
-from time import sleep
 from datetime import datetime
-from ctparse.ctparse import _timeout, ctparse, _seq_match, _match_rule
+from ctparse.ctparse import ctparse, _seq_match, _match_rule
 from ctparse.types import Time
 
 
 class TestCTParse(TestCase):
-    def test_timeout(self):
-        t_fun = _timeout(0.5)
-        with self.assertRaises(Exception):
-            sleep(1)
-            t_fun()
-        t_fun = _timeout(0)
-        t_fun()  # all good
 
     def test_ctparse(self):
         txt = '12.12.2020'
@@ -80,11 +72,11 @@ class TestCTParse(TestCase):
         self.assertEqual(list(_seq_match(
             [1, 2, 1, 2, 2],
             [lambda x: x, make_rm(1), lambda x: x, make_rm(2), lambda x: x])),
-                         [])
+            [])
         self.assertEqual(list(_seq_match(
             [1, 2, 1, 2, 2, 3],
             [lambda x: x, make_rm(1), lambda x: x, make_rm(2), lambda x: x])),
-                         [[2, 4]])
+            [[2, 4]])
 
     def test_match_rule(self):
         self.assertEqual(list(_match_rule([], ['not empty'])), [])

--- a/tests/test_timers.py
+++ b/tests/test_timers.py
@@ -1,0 +1,22 @@
+from ctparse.timers import timeout, CTParseTimeoutError, timeit
+from unittest import TestCase
+import time
+
+
+class TimersTest(TestCase):
+
+    def test_timeout(self):
+        t_fun = timeout(0.5)
+        with self.assertRaises(CTParseTimeoutError):
+            time.sleep(1.0)
+            t_fun()
+        t_fun = timeout(0)
+        t_fun()  # all good
+
+    def test_timeit(self):
+        def fun(x):
+            return x * x
+
+        result, elapsed = timeit(fun)(3)
+        self.assertEqual(result, 9)
+        self.assertIsInstance(elapsed, float)


### PR DESCRIPTION
Create a `ctparse.timers` module that contains only timing functions, this helps reduce the size of the `ctparse.ctparse` module.